### PR TITLE
#7 Revisit JSON-based cloning and equality semantics

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,13 @@ npm install @charliewilco/abstract-mutable-store
   updated value.
 - `subscribe(listener)` registers a listener and returns an unsubscribe function.
 
+By default, `mutate()` clones state with
+[`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone), so
+state can include values such as `Date`, `Map`, `Set`, `undefined` fields, and circular references.
+Values that `structuredClone` cannot clone, such as functions, `WeakMap`, `WeakSet`, and symbol
+values, require a custom clone function. Custom class instances should also provide a clone function
+when prototype identity or methods need to be preserved.
+
 To use it, extend `AbstractMutableStore` with the domain-specific methods your app needs:
 
 ```ts
@@ -120,15 +127,41 @@ function App() {
 }
 ```
 
-## Custom equality
+## Custom clone and equality
 
-Stores use a JSON-based equality check by default. You can pass a custom equality function when
-only part of the state should determine whether subscribers are notified:
+Stores use a cycle-aware deep equality check by default. It compares `Date` values by timestamp,
+preserves the difference between missing fields and `undefined` fields, and treats functions as
+equal only when they are the same reference.
+
+You can pass a custom equality function when only part of the state should determine whether
+subscribers are notified:
 
 ```ts
 class VersionedStore extends AbstractMutableStore<{ version: number; value: string }> {
 	constructor() {
 		super({ version: 1, value: "initial" }, (a, b) => a.version === b.version);
+	}
+}
+```
+
+For state that needs custom cloning semantics, pass an options object with `clone`. The options
+object can also contain `equality`:
+
+```ts
+interface State {
+	callback: () => void;
+	label: string;
+}
+
+class CallbackStore extends AbstractMutableStore<State> {
+	constructor(callback: () => void) {
+		super(
+			{ callback, label: "ready" },
+			{
+				clone: (state) => ({ ...state }),
+				equality: (a, b) => a.label === b.label && a.callback === b.callback,
+			},
+		);
 	}
 }
 ```

--- a/src/abstract-mutable-store.test.ts
+++ b/src/abstract-mutable-store.test.ts
@@ -52,6 +52,43 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(store.getSnapshot(), { version: 2, value: "newer" });
 	});
 
+	it("uses the provided equality function from options", () => {
+		class TestStore extends AbstractMutableStore<{ version: number; value: string }> {
+			constructor() {
+				super({ version: 1, value: "old" }, { equality: (a, b) => a.version === b.version });
+			}
+		}
+
+		const store = new TestStore();
+		const calls: Array<{ version: number; value: string }> = [];
+
+		store.subscribe((value) => calls.push(value));
+		store.setValue({ version: 1, value: "new" });
+		store.setValue({ version: 2, value: "newer" });
+
+		assert.deepEqual(calls, [{ version: 2, value: "newer" }]);
+		assert.deepEqual(store.getSnapshot(), { version: 2, value: "newer" });
+	});
+
+	it("uses the provided clone function from options", () => {
+		const callback = () => "value";
+
+		class TestStore extends AbstractMutableStore<{ name: string; callback: () => string }> {
+			constructor() {
+				super({ name: "before", callback }, { clone: (value) => ({ ...value }) });
+			}
+		}
+
+		const store = new TestStore();
+
+		const result = store.mutate((draft) => {
+			draft.name = "after";
+		});
+
+		assert.deepEqual(result, { name: "after", callback });
+		assert.deepEqual(store.getSnapshot(), { name: "after", callback });
+	});
+
 	it("does not notify unsubscribed listeners", () => {
 		const store = createMockStore({ prop1: "value1", prop2: 42 });
 

--- a/src/abstract-mutable-store.ts
+++ b/src/abstract-mutable-store.ts
@@ -1,11 +1,18 @@
 import { isEqual, type EqualityCheck } from "./base-equality";
-import { mutate, type Mutator } from "./mutate";
+import { cloneValue, mutate, type CloneValue, type Mutator } from "./mutate";
+
+export interface AbstractMutableStoreOptions<T> {
+	equality?: EqualityCheck<T>;
+	clone?: CloneValue<T>;
+}
 
 /**
  * An abstract class for creating a store that is compliant with `useSyncExternalStore`.
  */
 export abstract class AbstractMutableStore<T> {
 	private listeners: Set<(value: T) => void> = new Set();
+	private equalityFn: EqualityCheck<T>;
+	private cloneFn: CloneValue<T>;
 
 	/**
 	 * Creates a new instance of `AbstractStore`.
@@ -14,8 +21,16 @@ export abstract class AbstractMutableStore<T> {
 	 */
 	constructor(
 		protected value: T,
-		private equalityFn: EqualityCheck<T> = isEqual,
-	) {}
+		options: EqualityCheck<T> | AbstractMutableStoreOptions<T> = isEqual,
+	) {
+		if (typeof options === "function") {
+			this.equalityFn = options;
+			this.cloneFn = cloneValue;
+		} else {
+			this.equalityFn = options.equality ?? isEqual;
+			this.cloneFn = options.clone ?? cloneValue;
+		}
+	}
 
 	/**
 	 * Returns a snapshot of the current value of the store.
@@ -48,7 +63,7 @@ export abstract class AbstractMutableStore<T> {
 	 * @returns The updated value.
 	 */
 	public mutate(mutator: Mutator<T>): T {
-		const newValue = mutate(this.value, mutator);
+		const newValue = mutate(this.value, mutator, { clone: this.cloneFn });
 
 		if (this.equalityFn(this.value, newValue)) {
 			return this.value;

--- a/src/base-equality.test.ts
+++ b/src/base-equality.test.ts
@@ -45,6 +45,72 @@ describe("checkEquality", () => {
 		assert.equal(checkEquality(a, b), true);
 	});
 
+	it("returns true for Date values with the same timestamp", () => {
+		const a = { createdAt: new Date("2026-06-06T12:00:00.000Z") };
+		const b = { createdAt: new Date("2026-06-06T12:00:00.000Z") };
+
+		assert.equal(checkEquality(a, b), true);
+	});
+
+	it("returns false for Date values with different timestamps", () => {
+		const a = { createdAt: new Date("2026-06-06T12:00:00.000Z") };
+		const b = { createdAt: new Date("2026-06-06T12:00:01.000Z") };
+
+		assert.equal(checkEquality(a, b), false);
+	});
+
+	it("preserves the difference between undefined fields and missing fields", () => {
+		assert.equal(checkEquality({ optional: undefined }, { optional: undefined }), true);
+		assert.equal(checkEquality({ optional: undefined }, {}), false);
+	});
+
+	it("returns true for Map and Set values with matching contents", () => {
+		const a = {
+			ids: new Set([1, 2]),
+			labels: new Map([
+				["one", "first"],
+				["two", "second"],
+			]),
+		};
+		const b = {
+			ids: new Set([2, 1]),
+			labels: new Map([
+				["two", "second"],
+				["one", "first"],
+			]),
+		};
+
+		assert.equal(checkEquality(a, b), true);
+	});
+
+	it("returns true for equivalent circular references", () => {
+		interface CircularState {
+			name: string;
+			self?: CircularState;
+		}
+
+		const a: CircularState = { name: "same" };
+		const b: CircularState = { name: "same" };
+		a.self = a;
+		b.self = b;
+
+		assert.equal(checkEquality(a, b), true);
+	});
+
+	it("returns false for different circular references", () => {
+		interface CircularState {
+			name: string;
+			self?: CircularState;
+		}
+
+		const a: CircularState = { name: "same" };
+		const b: CircularState = { name: "same" };
+		a.self = a;
+		b.self = { name: "different" };
+
+		assert.equal(checkEquality(a, b), false);
+	});
+
 	it("returns true for null values", () => {
 		assert.equal(checkEquality(null, null), true);
 	});

--- a/src/base-equality.ts
+++ b/src/base-equality.ts
@@ -1,22 +1,198 @@
+export type EqualityCheck<T = unknown> = (a: T, b: T) => boolean;
+
+type SeenPairs = Array<readonly [object, object]>;
+
 function checkEquality(a: unknown, b: unknown): boolean {
+	return areEqual(a, b, []);
+}
+
+function areEqual(a: unknown, b: unknown, seen: SeenPairs): boolean {
 	if (Object.is(a, b)) {
 		return true;
 	}
 
-	if (typeof a !== typeof b || a === null || b === null) {
+	if (typeof a !== typeof b || !isObject(a) || !isObject(b)) {
 		return false;
 	}
 
-	const serializedA = JSON.stringify(a);
-	const serializedB = JSON.stringify(b);
-
-	if (serializedA === undefined || serializedB === undefined) {
+	if (typeof a === "function" || typeof b === "function") {
 		return false;
 	}
 
-	return serializedA === serializedB;
+	if (hasSeenPair(a, b, seen)) {
+		return true;
+	}
+
+	if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
+		return false;
+	}
+
+	if (a instanceof Date && b instanceof Date) {
+		return Object.is(a.getTime(), b.getTime());
+	}
+
+	if (a instanceof RegExp && b instanceof RegExp) {
+		return a.source === b.source && a.flags === b.flags && a.lastIndex === b.lastIndex;
+	}
+
+	if (a instanceof ArrayBuffer || b instanceof ArrayBuffer) {
+		return a instanceof ArrayBuffer && b instanceof ArrayBuffer && areArrayBuffersEqual(a, b);
+	}
+
+	if (ArrayBuffer.isView(a) || ArrayBuffer.isView(b)) {
+		return ArrayBuffer.isView(a) && ArrayBuffer.isView(b) && areArrayBufferViewsEqual(a, b);
+	}
+
+	if (a instanceof Map && b instanceof Map) {
+		return areMapsEqual(a, b, seen);
+	}
+
+	if (a instanceof Set && b instanceof Set) {
+		return areSetsEqual(a, b, seen);
+	}
+
+	if (a instanceof WeakMap || a instanceof WeakSet || a instanceof Promise) {
+		return false;
+	}
+
+	return areObjectsEqual(a, b, seen);
 }
 
-export type EqualityCheck<T = unknown> = (a: T, b: T) => boolean;
+function isObject(value: unknown): value is object {
+	return (typeof value === "object" || typeof value === "function") && value !== null;
+}
+
+function hasSeenPair(a: object, b: object, seen: SeenPairs): boolean {
+	if (seen.some(([seenA, seenB]) => seenA === a && seenB === b)) {
+		return true;
+	}
+
+	seen.push([a, b]);
+
+	return false;
+}
+
+function areMapsEqual(
+	a: Map<unknown, unknown>,
+	b: Map<unknown, unknown>,
+	seen: SeenPairs,
+): boolean {
+	if (a.size !== b.size) {
+		return false;
+	}
+
+	const bEntries = Array.from(b);
+	const matchedIndexes = new Set<number>();
+
+	for (const [aKey, aValue] of a) {
+		let matchedIndex = -1;
+
+		for (const [index, [bKey, bValue]] of bEntries.entries()) {
+			const candidateSeen = [...seen];
+
+			if (
+				!matchedIndexes.has(index) &&
+				areEqual(aKey, bKey, candidateSeen) &&
+				areEqual(aValue, bValue, candidateSeen)
+			) {
+				matchedIndex = index;
+				seen.splice(0, seen.length, ...candidateSeen);
+				break;
+			}
+		}
+
+		if (matchedIndex === -1) {
+			return false;
+		}
+
+		matchedIndexes.add(matchedIndex);
+	}
+
+	return true;
+}
+
+function areSetsEqual(a: Set<unknown>, b: Set<unknown>, seen: SeenPairs): boolean {
+	if (a.size !== b.size) {
+		return false;
+	}
+
+	const bValues = Array.from(b);
+	const matchedIndexes = new Set<number>();
+
+	for (const aValue of a) {
+		let matchedIndex = -1;
+
+		for (const [index, bValue] of bValues.entries()) {
+			const candidateSeen = [...seen];
+
+			if (!matchedIndexes.has(index) && areEqual(aValue, bValue, candidateSeen)) {
+				matchedIndex = index;
+				seen.splice(0, seen.length, ...candidateSeen);
+				break;
+			}
+		}
+
+		if (matchedIndex === -1) {
+			return false;
+		}
+
+		matchedIndexes.add(matchedIndex);
+	}
+
+	return true;
+}
+
+function areArrayBuffersEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+	return areByteArraysEqual(new Uint8Array(a), new Uint8Array(b));
+}
+
+function areArrayBufferViewsEqual(a: ArrayBufferView, b: ArrayBufferView): boolean {
+	return (
+		Object.getPrototypeOf(a) === Object.getPrototypeOf(b) &&
+		areByteArraysEqual(
+			new Uint8Array(a.buffer, a.byteOffset, a.byteLength),
+			new Uint8Array(b.buffer, b.byteOffset, b.byteLength),
+		)
+	);
+}
+
+function areByteArraysEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.byteLength !== b.byteLength) {
+		return false;
+	}
+
+	return a.every((value, index) => value === b[index]);
+}
+
+function areObjectsEqual(a: object, b: object, seen: SeenPairs): boolean {
+	const aKeys = enumerableOwnKeys(a);
+	const bKeys = enumerableOwnKeys(b);
+
+	if (aKeys.length !== bKeys.length) {
+		return false;
+	}
+
+	for (const key of aKeys) {
+		if (!Object.prototype.propertyIsEnumerable.call(b, key)) {
+			return false;
+		}
+
+		if (!areEqual(getProperty(a, key), getProperty(b, key), seen)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function enumerableOwnKeys(value: object): Array<string | symbol> {
+	return Reflect.ownKeys(value).filter((key) =>
+		Object.prototype.propertyIsEnumerable.call(value, key),
+	);
+}
+
+function getProperty(value: object, key: string | symbol): unknown {
+	return (value as Record<string | symbol, unknown>)[key];
+}
 
 export const isEqual: EqualityCheck = checkEquality;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
-export { AbstractMutableStore } from "./abstract-mutable-store";
+export {
+	AbstractMutableStore,
+	type AbstractMutableStoreOptions,
+} from "./abstract-mutable-store";
 export { isEqual, type EqualityCheck } from "./base-equality";
-export { mutate, type Mutator } from "./mutate";
+export {
+	cloneValue,
+	mutate,
+	type CloneValue,
+	type MutateOptions,
+	type Mutator,
+} from "./mutate";

--- a/src/mutate.test.ts
+++ b/src/mutate.test.ts
@@ -23,6 +23,109 @@ describe("safelyMutate", () => {
 		assert.deepEqual(arr, [1, 2, 3]);
 	});
 
+	it("clones Date values without converting them to strings", () => {
+		const obj = { createdAt: new Date("2026-06-06T12:00:00.000Z"), name: "draft" };
+		const newObj = safelyMutate(obj, (draft) => {
+			draft.createdAt.setUTCFullYear(2027);
+			draft.name = "published";
+		});
+
+		assert.equal(newObj.createdAt instanceof Date, true);
+		assert.equal(newObj.createdAt.toISOString(), "2027-06-06T12:00:00.000Z");
+		assert.equal(obj.createdAt.toISOString(), "2026-06-06T12:00:00.000Z");
+		assert.deepEqual(obj, { createdAt: new Date("2026-06-06T12:00:00.000Z"), name: "draft" });
+	});
+
+	it("preserves undefined fields when cloning objects", () => {
+		const obj: { name: string; optional: string | undefined } = {
+			name: "before",
+			optional: undefined,
+		};
+
+		const newObj = safelyMutate(obj, (draft) => {
+			draft.name = "after";
+		});
+
+		assert.equal(Object.hasOwn(newObj, "optional"), true);
+		assert.equal(newObj.optional, undefined);
+		assert.equal(Object.hasOwn(obj, "optional"), true);
+		assert.deepEqual(obj, { name: "before", optional: undefined });
+	});
+
+	it("clones Map and Set values", () => {
+		const obj = {
+			ids: new Set([1, 2]),
+			labels: new Map([
+				["one", "first"],
+				["two", "second"],
+			]),
+		};
+
+		const newObj = safelyMutate(obj, (draft) => {
+			draft.ids.add(3);
+			draft.labels.set("three", "third");
+		});
+
+		assert.deepEqual(Array.from(newObj.ids), [1, 2, 3]);
+		assert.deepEqual(Array.from(newObj.labels), [
+			["one", "first"],
+			["two", "second"],
+			["three", "third"],
+		]);
+		assert.deepEqual(Array.from(obj.ids), [1, 2]);
+		assert.deepEqual(Array.from(obj.labels), [
+			["one", "first"],
+			["two", "second"],
+		]);
+	});
+
+	it("preserves circular references when cloning objects", () => {
+		interface CircularState {
+			name: string;
+			self?: CircularState;
+		}
+
+		const obj: CircularState = { name: "before" };
+		obj.self = obj;
+
+		const newObj = safelyMutate(obj, (draft) => {
+			draft.name = "after";
+		});
+
+		assert.notEqual(newObj, obj);
+		assert.equal(newObj.self, newObj);
+		assert.equal(obj.self, obj);
+		assert.equal(obj.name, "before");
+		assert.equal(newObj.name, "after");
+	});
+
+	it("throws for function values with the default clone behavior", () => {
+		const obj = { name: "before", callback: () => "value" };
+
+		assert.throws(
+			() =>
+				safelyMutate(obj, (draft) => {
+					draft.name = "after";
+				}),
+			/structuredClone/,
+		);
+	});
+
+	it("uses a custom clone function for state that structuredClone cannot clone", () => {
+		const obj = { name: "before", callback: () => "value" };
+		const newObj = safelyMutate(
+			obj,
+			(draft) => {
+				draft.name = "after";
+			},
+			{ clone: (value) => ({ ...value }) },
+		);
+
+		assert.equal(newObj.name, "after");
+		assert.equal(newObj.callback, obj.callback);
+		assert.deepEqual(obj, { name: "before", callback: obj.callback });
+	});
+
 	it("uses returned string values", () => {
 		const str = "hello";
 		const newStr = safelyMutate(str, () => {

--- a/src/mutate.ts
+++ b/src/mutate.ts
@@ -1,16 +1,39 @@
 export type Mutator<T> = (draft: T) => void | T;
+export type CloneValue<T = unknown> = (value: T) => T;
+type StructuredClone = <T>(value: T) => T;
 
-export function mutate<T>(value: T, mutator: Mutator<T>): T {
-	const draft = cloneValue(value);
+const runtimeStructuredClone = (
+	globalThis as typeof globalThis & { structuredClone?: StructuredClone }
+).structuredClone;
+
+export interface MutateOptions<T> {
+	clone?: CloneValue<T>;
+}
+
+export function mutate<T>(value: T, mutator: Mutator<T>, options: MutateOptions<T> = {}): T {
+	const draft = (options.clone ?? cloneValue)(value);
 	const result = mutator(draft);
 
 	return result === undefined ? draft : result;
 }
 
-function cloneValue<T>(value: T): T {
+export function cloneValue<T>(value: T): T {
 	if (typeof value !== "object" || value === null) {
 		return value;
 	}
 
-	return JSON.parse(JSON.stringify(value));
+	if (typeof runtimeStructuredClone !== "function") {
+		throw new TypeError(
+			"Default mutation cloning requires structuredClone. Provide a clone option for this runtime.",
+		);
+	}
+
+	try {
+		return runtimeStructuredClone(value);
+	} catch (error) {
+		throw new TypeError(
+			"Default mutation cloning uses structuredClone and cannot clone this value. Provide a clone option for custom state semantics.",
+			{ cause: error },
+		);
+	}
 }


### PR DESCRIPTION
Summary
- Replace JSON-based mutation cloning with a structuredClone default that preserves Date, Map, Set, undefined fields, and circular references.
- Add configurable clone hooks for mutate() and AbstractMutableStore while preserving the existing equality-function constructor form.
- Replace JSON.stringify equality with cycle-aware deep equality covering Date, Map, Set, undefined fields, function references, and circular structures.
- Document the default state model and unsupported/custom-clone cases in Readme.md.

AC Coverage
- [x] Unsupported state shapes are documented or handled intentionally.
- [x] Tests cover Date according to the chosen behavior.
- [x] Tests cover undefined fields according to the chosen behavior.
- [x] Tests cover functions according to the chosen behavior.
- [x] Tests cover circular references according to the chosen behavior.
- [x] mutate and isEqual behavior are consistent with the package identity from the positioning issue.

Testing
- npm run check
- npm pack --dry-run
- node -e 'import("./dist/index.mjs").then((m) => { const value = { date: new Date("2026-06-06T12:00:00.000Z") }; const next = m.mutate(value, (draft) => { draft.date.setUTCFullYear(2027); }); if (!(next.date instanceof Date) || next.date.getUTCFullYear() !== 2027 || value.date.getUTCFullYear() !== 2026) process.exit(1); })'

Notes/Risks
- Default mutation cloning now requires structuredClone. Values it cannot clone, such as function-bearing state, fail loudly unless callers pass a custom clone hook.
- Existing super(initial, equalityFn) usage remains supported; new clone/equality configuration uses super(initial, { clone, equality }).

Resolves #7
