### PR TITLE
#6 Improve React integration guidance

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [22, 24]
+        node: [24, 25, 26]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node }}

--- a/Readme.md
+++ b/Readme.md
@@ -96,15 +96,19 @@ const store = new AbstractMutableStore({ foo: 1 });
 
 ### With React
 
+Create app-wide store instances outside React render paths, then subscribe to them with
+`useSyncExternalStore`. React will call `getSnapshot()` during render, subscribe after commit, and
+re-render only after the store notifies it that a committed value changed.
+
 ```tsx
 import { AbstractMutableStore } from "@charliewilco/abstract-mutable-store";
 import { useSyncExternalStore } from "react";
 
-interface State {
+interface CounterState {
 	count: number;
 }
 
-class CountStore extends AbstractMutableStore<State> {
+class CounterStore extends AbstractMutableStore<CounterState> {
 	constructor() {
 		super({ count: 0 });
 	}
@@ -122,26 +126,60 @@ class CountStore extends AbstractMutableStore<State> {
 	}
 }
 
-const store = new CountStore();
+const counterStore = new CounterStore();
 
-function SyncedCount() {
-	const { count } = useSyncExternalStore(
-		(cb) => store.subscribe(cb),
-		() => store.getSnapshot(),
+function useCounterState() {
+	return useSyncExternalStore(
+		(listener) => counterStore.subscribe(listener),
+		() => counterStore.getSnapshot(),
+		() => counterStore.getSnapshot(),
 	);
+}
 
-	return <h1>Count: {count}</h1>;
+function Counter() {
+	const { count } = useCounterState();
+
+	return (
+		<section>
+			<h1>Count: {count}</h1>
+			<button type="button" onClick={() => counterStore.decrement()}>
+				Decrement
+			</button>
+			<button type="button" onClick={() => counterStore.increment()}>
+				Increment
+			</button>
+		</section>
+	);
 }
 
 function App() {
-	return (
-		<div>
-			<SyncedCount />
-			<button onClick={() => store.increment()}>Increment</button>
-		</div>
-	);
+	return <Counter />;
 }
 ```
+
+Keep the store instance stable. A module-level singleton is appropriate for shared client-side app
+state, because every component subscribes to the same listener set and reads the same snapshot. Do
+not create a new store in a component body; that resets state on render and gives React a different
+subscription target. If the state is request-specific or user-specific during server rendering,
+create the store in that request scope and pass it through your app rather than sharing one process
+singleton.
+
+Subscriptions are change notifications, not event replay. `subscribe(listener)` stores the listener
+and returns an unsubscribe function; it does not call the listener immediately. React gets the first
+value from `getSnapshot()`, then the store calls listeners only when `setValue()` or `mutate()`
+commits a value that is not equal according to the store equality function. Avoid mutating the object
+returned by `getSnapshot()` directly; expose domain methods that call `setValue()` or `mutate()` so
+the store can clone, compare, update, and notify consistently.
+
+The wrapper functions around `subscribe()` and `getSnapshot()` are intentional. Class methods are
+not automatically bound in JavaScript, so passing `counterStore.subscribe` directly would lose its
+`this` value.
+
+This package does not currently export a React helper or selector hook. Read the full store snapshot
+with `useSyncExternalStore` and derive values during render, or split state into smaller stores when
+components need narrower updates. A future `useStore()` or `useStoreSelector()` API should live in a
+separate React entrypoint with React as a peer dependency, keeping React out of the core package
+dependency graph.
 
 ## Custom clone and equality
 
@@ -186,9 +224,9 @@ class CallbackStore extends AbstractMutableStore<State> {
 
 This package currently promises the subclass-based store primitive described above. A concrete
 `createStore` helper is tracked in
-[#3](https://github.com/charliewilco/abstract-mutable-store/issues/3), and expanded React
-integration guidance is tracked in
-[#6](https://github.com/charliewilco/abstract-mutable-store/issues/6).
+[#3](https://github.com/charliewilco/abstract-mutable-store/issues/3). React helper hooks or
+selector support should be introduced only as a separate optional entrypoint, not as part of the
+framework-agnostic core export.
 
 ## Development
 

--- a/Readme.md
+++ b/Readme.md
@@ -181,6 +181,23 @@ components need narrower updates. A future `useStore()` or `useStoreSelector()` 
 separate React entrypoint with React as a peer dependency, keeping React out of the core package
 dependency graph.
 
+### Compared with BehaviorSubject
+
+`BehaviorSubject` from RxJS is a close mental model for React external stores: it keeps a current
+value, lets subscribers observe future changes, and can expose the current value synchronously for
+`useSyncExternalStore`.
+
+`AbstractMutableStore` is intentionally narrower. It is useful when you want a small, framework-free
+store class with domain methods, built-in clone/equality behavior, and no observable pipeline API.
+Instead of pushing arbitrary values through `.next()`, consumers call methods such as `increment()`
+or `renameProject()` that decide whether to use `setValue()` or `mutate()`. Subscribers are notified
+only after the committed value changes according to the store equality function.
+
+Use `BehaviorSubject` when your app already depends on RxJS or needs observable composition,
+operators, multicasting, cancellation, or stream interop. Use this package when the store is mostly
+a synchronous state holder for React-compatible snapshots and you want the public API to be a
+domain-specific class rather than an observable stream.
+
 ## Custom clone and equality
 
 Stores use a cycle-aware deep equality check by default. It compares `Date` values by timestamp,


### PR DESCRIPTION
## Summary

- Expands the README React section with a fuller `useSyncExternalStore` example.
- Documents stable store instance guidance, subscription behavior, direct snapshot mutation caveats, class-method binding, and a BehaviorSubject comparison.
- Documents the current selector/helper decision: no React helper is exported yet, and future helper hooks should live behind an optional React entrypoint with React as a peer dependency.
- Updates the CI matrix to Node 24, 25, and 26.
- Removes the CommonJS package output so the package now publishes ESM plus TypeScript declarations only.

## AC Coverage

- [x] README has a clear React example using `useSyncExternalStore`.
- [x] Docs explain when to create/store singleton instances.
- [x] Docs explain that selector support is intentionally omitted today.
- [x] No React helper was added, so React remains out of the core package dependency graph.

## Testing

- `npm run check`
- `npm pack --dry-run`
- `test -f dist/index.mjs && test ! -e dist/index.cjs`
- `node --input-type=module -e "const pkg = await import('./dist/index.mjs'); if (!pkg.AbstractMutableStore || !pkg.mutate) throw new Error('missing exports'); console.log(Object.keys(pkg).sort().join(','));"`
- `node -e "try { require('@charliewilco/abstract-mutable-store'); throw new Error('require unexpectedly succeeded'); } catch (error) { if (error.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw error; console.log(error.code); }"`

## Notes/Risks

- Removing CJS is a breaking package-consumption change for CommonJS `require()` users. The package metadata now exposes only the ESM import condition and `dist/index.mjs` build output.
- Adding `useStore()` or `useStoreSelector()` would be a separate package-surface change and should use a React-specific optional entrypoint rather than the framework-agnostic root export.

Resolves #6
