### PR TITLE
Remove CommonJS package output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ so concrete store classes can focus on domain methods.
 The package is intentionally a store primitive, not a React hook library or an immutable-state
 framework. React is the primary integration target, but the core API is framework-agnostic.
 
-The package publishes both ESM and CommonJS bundles, plus TypeScript declarations.
+The package publishes an ESM bundle and TypeScript declarations.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -6,15 +6,14 @@
 	"files": [
 		"dist/**/*"
 	],
-	"main": "dist/index.cjs",
+	"main": "dist/index.mjs",
 	"module": "dist/index.mjs",
 	"types": "dist/index.d.ts",
 	"typings": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"import": "./dist/index.mjs",
-			"require": "./dist/index.cjs"
+			"import": "./dist/index.mjs"
 		}
 	},
 	"sideEffects": false,

--- a/rolldown.config.mjs
+++ b/rolldown.config.mjs
@@ -4,17 +4,9 @@ import { defineConfig } from "rolldown";
 export default defineConfig({
 	input: "src/index.ts",
 	external: (id) => !/^[./]/.test(id),
-	output: [
-		{
-			file: "dist/index.cjs",
-			format: "cjs",
-			sourcemap: true,
-			exports: "named",
-		},
-		{
-			file: "dist/index.mjs",
-			format: "esm",
-			sourcemap: true,
-		},
-	],
+	output: {
+		file: "dist/index.mjs",
+		format: "esm",
+		sourcemap: true,
+	},
 });


### PR DESCRIPTION
## Summary

- Removes the CommonJS bundle from the Rolldown build.
- Drops the package `require` export and points `main` at the ESM bundle.
- Updates the README package-format copy to say the package publishes ESM plus TypeScript declarations.

## Testing

- `npm run check`
- `npm pack --dry-run`
- `test -f dist/index.mjs && test ! -e dist/index.cjs`
- `node --input-type=module -e "const pkg = await import('./dist/index.mjs'); if (!pkg.AbstractMutableStore || !pkg.mutate) throw new Error('missing exports'); console.log(Object.keys(pkg).sort().join(','));"`
- `node -e "try { require('@charliewilco/abstract-mutable-store'); throw new Error('require unexpectedly succeeded'); } catch (error) { if (error.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw error; console.log(error.code); }"`

## Notes/Risks

- This is a breaking change for CommonJS `require()` consumers. ESM import consumers and TypeScript declarations remain supported.
- I intentionally did not add `"type": "module"` in this slice because the current test build emits `.tmp/test/*.js` with Node16 module settings; flipping package type would be a separate repo-internals migration rather than just removing the published CJS surface.
