### PR TITLE
Add draft update authoring API

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,10 +4,10 @@
 
 [![Publish](https://github.com/charliewilco/abstract-mutable-store/actions/workflows/publish.yml/badge.svg)](https://github.com/charliewilco/abstract-mutable-store/actions/workflows/publish.yml)
 
-Abstract Mutable Store is a tiny TypeScript base class for building app-specific external
-stores that need [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore)
-compatibility. It owns the common snapshot, subscription, mutation, cloning, and equality behavior
-so concrete store classes can focus on domain methods.
+Abstract Mutable Store is a tiny TypeScript base class for building app-specific external stores
+whose domain methods update state by mutating drafts. It owns the common snapshot, subscription,
+draft cloning, equality, and [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore)
+compatibility so concrete store classes can focus on domain behavior.
 
 The package is intentionally a store primitive, not a React hook library or an immutable-state
 framework. React is the primary integration target, but the core API is framework-agnostic.
@@ -27,16 +27,65 @@ needs:
 
 - `getSnapshot()` reads the current value.
 - `setValue(value)` replaces the value and notifies subscribers when it changed.
-- `mutate(mutator)` clones the current value, lets you mutate the draft, then stores the
+- `update(updater)` clones the current value, lets you mutate the draft, then stores the
   updated value.
+- `mutate(mutator)` is a compatibility alias for `update(updater)`.
 - `subscribe(listener)` registers a listener and returns an unsubscribe function.
 
 The standalone `mutate`, `cloneValue`, and `isEqual` exports are helpers that use the same default
 state semantics as the store. They are not a separate store API.
 
+### Draft authoring model
+
+Store methods should usually read like ordinary domain operations. Mutate the draft directly inside
+`update()`, and let the store handle cloning, equality, committing, and notifying subscribers:
+
+```ts
+interface Todo {
+	readonly id: string;
+	readonly title: string;
+	readonly done: boolean;
+}
+
+interface TodoState {
+	readonly todos: ReadonlyArray<Todo>;
+}
+
+class TodoStore extends AbstractMutableStore<TodoState> {
+	addTodo(title: string) {
+		this.update((draft) => {
+			draft.todos.push({
+				id: crypto.randomUUID(),
+				title,
+				done: false,
+			});
+		});
+	}
+
+	completeTodo(id: string) {
+		this.update((draft) => {
+			const todo = draft.todos.find((item) => item.id === id);
+
+			if (todo) {
+				todo.done = true;
+			}
+		});
+	}
+}
+```
+
+Drafts are typed as mutable even when the public snapshot type uses `readonly` fields or
+`ReadonlyArray`. That is a TypeScript-only authoring convenience; snapshots returned from
+`getSnapshot()` should still be treated as store-owned values and updated through domain methods.
+
+This is inspired by Immer's authoring model, but it is not an Immer replacement. The default draft
+behavior uses `structuredClone()` before running your updater, then the store's equality function
+decides whether to commit and notify. It does not provide proxy-based structural sharing, patch
+generation, or Immer's full collection of draft semantics.
+
 ### State model
 
-By default, `mutate()` clones state with
+By default, `update()` clones state with
 [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone), so
 state can include primitives, arrays, plain objects, `Date`, `Map`, `Set`, `ArrayBuffer`, typed
 arrays, `undefined` fields, and circular references. The default equality function is cycle-aware
@@ -44,7 +93,7 @@ and compares those shapes without JSON serialization.
 
 Values that `structuredClone` cannot clone, such as functions, `WeakMap`, `WeakSet`, promises, and
 symbol values inside objects, require a custom clone function before they can be used with
-`mutate()`. Custom class instances should also provide a clone function when prototype identity or
+`update()`. Custom class instances should also provide a clone function when prototype identity or
 methods need to be preserved.
 
 Use `setValue()` or a custom `clone` option when replacement semantics are clearer than draft
@@ -63,13 +112,13 @@ class CountStore extends AbstractMutableStore<State> {
 	}
 
 	increment() {
-		this.mutate((draft) => {
+		this.update((draft) => {
 			draft.count += 1;
 		});
 	}
 
 	decrement() {
-		this.mutate((draft) => {
+		this.update((draft) => {
 			draft.count -= 1;
 		});
 	}
@@ -114,13 +163,13 @@ class CounterStore extends AbstractMutableStore<CounterState> {
 	}
 
 	increment() {
-		this.mutate((draft) => {
+		this.update((draft) => {
 			draft.count += 1;
 		});
 	}
 
 	decrement() {
-		this.mutate((draft) => {
+		this.update((draft) => {
 			draft.count -= 1;
 		});
 	}
@@ -166,9 +215,9 @@ singleton.
 
 Subscriptions are change notifications, not event replay. `subscribe(listener)` stores the listener
 and returns an unsubscribe function; it does not call the listener immediately. React gets the first
-value from `getSnapshot()`, then the store calls listeners only when `setValue()` or `mutate()`
+value from `getSnapshot()`, then the store calls listeners only when `setValue()` or `update()`
 commits a value that is not equal according to the store equality function. Avoid mutating the object
-returned by `getSnapshot()` directly; expose domain methods that call `setValue()` or `mutate()` so
+returned by `getSnapshot()` directly; expose domain methods that call `setValue()` or `update()` so
 the store can clone, compare, update, and notify consistently.
 
 The wrapper functions around `subscribe()` and `getSnapshot()` are intentional. Class methods are
@@ -190,7 +239,7 @@ value, lets subscribers observe future changes, and can expose the current value
 `AbstractMutableStore` is intentionally narrower. It is useful when you want a small, framework-free
 store class with domain methods, built-in clone/equality behavior, and no observable pipeline API.
 Instead of pushing arbitrary values through `.next()`, consumers call methods such as `increment()`
-or `renameProject()` that decide whether to use `setValue()` or `mutate()`. Subscribers are notified
+or `renameProject()` that decide whether to use `setValue()` or `update()`. Subscribers are notified
 only after the committed value changes according to the store equality function.
 
 Use `BehaviorSubject` when your app already depends on RxJS or needs observable composition,

--- a/src/abstract-mutable-store.test.ts
+++ b/src/abstract-mutable-store.test.ts
@@ -81,7 +81,7 @@ describe("AbstractMutableStore", () => {
 
 		const store = new TestStore();
 
-		const result = store.mutate((draft) => {
+		const result = store.update((draft) => {
 			draft.name = "after";
 		});
 
@@ -118,14 +118,14 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(calls, []);
 	});
 
-	it("safely mutates the draft value", () => {
+	it("updates the store by mutating a draft value", () => {
 		class TestStore extends AbstractMutableStore<{ count: number }> {}
 
 		const store = new TestStore({ count: 0 });
 		const calls: Array<{ count: number }> = [];
 		store.subscribe((value) => calls.push(value));
 
-		const result = store.mutate((draft) => {
+		const result = store.update((draft) => {
 			draft.count += 1;
 		});
 
@@ -134,25 +134,76 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(calls, [{ count: 1 }]);
 	});
 
-	it("uses replacement values returned by mutators", () => {
+	it("uses replacement values returned by updaters", () => {
 		const store = createMockStore({ count: 0 });
 
-		const result = store.mutate(() => ({ count: 10 }));
+		const result = store.update(() => ({ count: 10 }));
 
 		assert.deepEqual(result, { count: 10 });
 		assert.deepEqual(store.getSnapshot(), { count: 10 });
 	});
 
-	it("does not notify when a mutation leaves the value equal", () => {
+	it("does not notify when an update leaves the value equal", () => {
 		const store = createMockStore({ count: 0 });
 		const calls: Array<{ count: number }> = [];
 
 		store.subscribe((value) => calls.push(value));
-		const result = store.mutate((draft) => {
+		const result = store.update((draft) => {
 			draft.count = 0;
 		});
 
 		assert.deepEqual(result, { count: 0 });
 		assert.deepEqual(calls, []);
+	});
+
+	it("treats readonly state as mutable inside update drafts", () => {
+		interface Todo {
+			readonly id: string;
+			readonly title: string;
+			readonly done: boolean;
+		}
+
+		interface TodoState {
+			readonly todos: ReadonlyArray<Todo>;
+			readonly meta: {
+				readonly completedCount: number;
+			};
+		}
+
+		class TodoStore extends AbstractMutableStore<TodoState> {
+			completeTodo(id: string) {
+				return this.update((draft) => {
+					const todo = draft.todos.find((item) => item.id === id);
+
+					if (todo) {
+						todo.done = true;
+						draft.meta.completedCount += 1;
+					}
+				});
+			}
+		}
+
+		const store = new TodoStore({
+			todos: [{ id: "1", title: "Draft docs", done: false }],
+			meta: { completedCount: 0 },
+		});
+
+		const result = store.completeTodo("1");
+
+		assert.deepEqual(result, {
+			todos: [{ id: "1", title: "Draft docs", done: true }],
+			meta: { completedCount: 1 },
+		});
+	});
+
+	it("keeps mutate as an alias for update", () => {
+		const store = createMockStore({ count: 0 });
+
+		const result = store.mutate((draft) => {
+			draft.count += 1;
+		});
+
+		assert.deepEqual(result, { count: 1 });
+		assert.deepEqual(store.getSnapshot(), { count: 1 });
 	});
 });

--- a/src/abstract-mutable-store.ts
+++ b/src/abstract-mutable-store.ts
@@ -1,5 +1,5 @@
 import { isEqual, type EqualityCheck } from "./base-equality";
-import { cloneValue, mutate, type CloneValue, type Mutator } from "./mutate";
+import { cloneValue, mutate, type CloneValue, type DraftUpdater } from "./mutate";
 
 export interface AbstractMutableStoreOptions<T> {
 	equality?: EqualityCheck<T>;
@@ -56,14 +56,14 @@ export abstract class AbstractMutableStore<T> {
 	}
 
 	/**
-	 * Applies the given mutation function to a draft of the current value.
+	 * Applies the given update function to a draft of the current value.
 	 *
-	 * @param mutationFn - A callback function that takes a draft of the current value, and mutates it
-	 *                     as needed.
+	 * @param updater - A callback function that takes a draft of the current value, and mutates it
+	 *                  as needed.
 	 * @returns The updated value.
 	 */
-	public mutate(mutator: Mutator<T>): T {
-		const newValue = mutate(this.value, mutator, { clone: this.cloneFn });
+	public update(updater: DraftUpdater<T>): T {
+		const newValue = mutate(this.value, updater, { clone: this.cloneFn });
 
 		if (this.equalityFn(this.value, newValue)) {
 			return this.value;
@@ -74,6 +74,11 @@ export abstract class AbstractMutableStore<T> {
 
 		return newValue;
 	}
+
+	public mutate(updater: DraftUpdater<T>): T {
+		return this.update(updater);
+	}
+
 	/**
 	 * Subscribes a listener function to changes in the store and returns an unsubscribe function.
 	 *

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ export {
 	cloneValue,
 	mutate,
 	type CloneValue,
+	type DraftUpdater,
+	type MutableDraft,
 	type MutateOptions,
 	type Mutator,
 } from "./mutate";

--- a/src/mutate.ts
+++ b/src/mutate.ts
@@ -1,4 +1,22 @@
-export type Mutator<T> = (draft: T) => void | T;
+type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+
+export type MutableDraft<T> = T extends Primitive
+	? T
+	: T extends (...args: Array<never>) => unknown
+		? T
+		: T extends Date
+			? T
+			: T extends ReadonlyMap<infer Key, infer Value>
+				? Map<MutableDraft<Key>, MutableDraft<Value>>
+				: T extends ReadonlySet<infer Value>
+					? Set<MutableDraft<Value>>
+					: T extends ReadonlyArray<infer Value>
+						? Array<MutableDraft<Value>>
+						: T extends object
+							? { -readonly [Key in keyof T]: MutableDraft<T[Key]> }
+							: T;
+export type DraftUpdater<T> = (draft: MutableDraft<T>) => void | T;
+export type Mutator<T> = DraftUpdater<T>;
 export type CloneValue<T = unknown> = (value: T) => T;
 type StructuredClone = <T>(value: T) => T;
 
@@ -10,11 +28,15 @@ export interface MutateOptions<T> {
 	clone?: CloneValue<T>;
 }
 
-export function mutate<T>(value: T, mutator: Mutator<T>, options: MutateOptions<T> = {}): T {
-	const draft = (options.clone ?? cloneValue)(value);
-	const result = mutator(draft);
+export function mutate<T>(
+	value: T,
+	updater: DraftUpdater<T>,
+	options: MutateOptions<T> = {},
+): T {
+	const draft = (options.clone ?? cloneValue)(value) as MutableDraft<T>;
+	const result = updater(draft);
 
-	return result === undefined ? draft : result;
+	return result === undefined ? (draft as T) : result;
 }
 
 export function cloneValue<T>(value: T): T {


### PR DESCRIPTION
## Summary

- Adds `AbstractMutableStore.update()` as the preferred store method for domain-specific draft updates.
- Keeps `mutate()` as a compatibility alias for existing callers.
- Introduces `MutableDraft<T>` and `DraftUpdater<T>` so readonly public state shapes are writable inside update drafts.
- Reframes the README around the draft-authoring model, including where it is and is not like Immer.

## Testing

- `npm run format`
- `npm run check`
- `npm pack --dry-run`
- `node --input-type=module -e "const pkg = await import('./dist/index.mjs'); class Store extends pkg.AbstractMutableStore { inc(){ return this.update(d => { d.count += 1; }); } } const store = new Store({ count: 0 }); const next = store.inc(); if (next.count !== 1 || store.getSnapshot().count !== 1) throw new Error('update failed'); console.log(Object.keys(pkg).sort().join(','));"`
- `git diff --check`

## Notes/Risks

- This makes `update()` the preferred class API but does not remove `mutate()`, so existing callers keep working.
- The mutable draft type is a TypeScript authoring convenience. The runtime behavior is still clone-then-update with equality-based notification, not Immer-style proxy structural sharing or patches.
