### PR TITLE
Run Node tests with tsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "0.1.0",
 			"license": "Unlicense",
 			"devDependencies": {
-				"@types/node": "^24.12.4",
-				"prettier": "^3.8.3",
-				"rolldown": "^1.0.3",
+				"@types/node": "^25.9.2",
+				"prettier": "^3.8.4",
+				"rolldown": "^1.1.0",
 				"tsx": "^4.22.4",
 				"typescript": "^6.0.3"
 			}
@@ -512,9 +512,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+			"version": "0.134.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.134.0.tgz",
+			"integrity": "sha512-T0xuRRKrQFmocH8y+jGfpmSkGcheaJExY9lEihmR1Gm2aH+75B8CzgU2rABRQSzzDxLjZ15Sc0bRVLj5lVeNXQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -522,9 +522,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-			"integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.0.tgz",
+			"integrity": "sha512-gCYzGOSkYY6Z034suzd20euvds7lPzMEEla62DJGE/ZAlR4OMBnNbvnBSsIGUCAr52gaWMsloGxP4tVGtN5aCA==",
 			"cpu": [
 				"arm64"
 			],
@@ -539,9 +539,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-			"integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.0.tgz",
+			"integrity": "sha512-JQBD77MNgu+4Z6RAyg69acugdrhhVoWesr3l47zohYZ2YV2fwkWMArkN/2p4l6Ei+Sno7W5q+UsKdVWq5Ens0w==",
 			"cpu": [
 				"arm64"
 			],
@@ -556,9 +556,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-			"integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.0.tgz",
+			"integrity": "sha512-p/8cXUTK4Sob604e+xxPhVSbDFf29E6J0l/xESM9rdCfn3aDai3nEs6TnMHUsdD5aNlFz0+gDbiGlozLKGa2YA==",
 			"cpu": [
 				"x64"
 			],
@@ -573,9 +573,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-			"integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.0.tgz",
+			"integrity": "sha512-KbtOSlVv6fElujiZWMcC3aQYhEwLVVf073RcwlSmpGQvIsKZFUqc0ef4sjUuurRwfbiI6JJXji9DQn+86hawmQ==",
 			"cpu": [
 				"x64"
 			],
@@ -590,9 +590,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-			"integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.0.tgz",
+			"integrity": "sha512-9fZ9i0o0/MQaw7om6Z6TsT7tfCk0jtbEFtC+aPqZL5RNsGWNcHvn6EHgL3dAprjq+AZzPTAQjg2JtpJaMt+6pg==",
 			"cpu": [
 				"arm"
 			],
@@ -607,9 +607,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-			"integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.0.tgz",
+			"integrity": "sha512-+tog7T66i+yFyIuuAnjL6xmW182W/qTBOUt6BtQ6lBIM1Eikh/fSMz4HGgvuCp5uU0zuIVWng7kDYthjCMOHcg==",
 			"cpu": [
 				"arm64"
 			],
@@ -624,9 +624,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-			"integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.0.tgz",
+			"integrity": "sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -641,9 +641,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-			"integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.0.tgz",
+			"integrity": "sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -658,9 +658,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-			"integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.0.tgz",
+			"integrity": "sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -675,9 +675,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-			"integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.0.tgz",
+			"integrity": "sha512-IdovCmfROFmpTLahdecTDFL74aLERVYN68F/mLZjfVh6LfoplPfI6deyHNMTcVujbokDV5k05XrFO22zfv+qjg==",
 			"cpu": [
 				"x64"
 			],
@@ -692,9 +692,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-			"integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.0.tgz",
+			"integrity": "sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==",
 			"cpu": [
 				"x64"
 			],
@@ -709,9 +709,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-			"integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.0.tgz",
+			"integrity": "sha512-4+fexHayrLCWpriPh4c6dNvL4an34DEZCG7zOM/FD5QNF6h8DT+bDXzyB/kfC8lDJbaFb7jKShtnjDQFXVQEjg==",
 			"cpu": [
 				"arm64"
 			],
@@ -726,9 +726,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-			"integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.0.tgz",
+			"integrity": "sha512-SbL++MNmOw6QamrwIGDMSSfM4ceTzFr+RjbOExJSLLBinScU4WI5OdA413h1qwPw2yH7lVF1+H4svQ+6mSXKTQ==",
 			"cpu": [
 				"wasm32"
 			],
@@ -745,9 +745,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-			"integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.0.tgz",
+			"integrity": "sha512-+xTE6XC7wBgk0VKRXGG+QAnyW5S9b8vfsFpiMjf0waQTmSQSU8onsH/beyZ8X4aXVveJnotiy7VDjLOaW8bTrg==",
 			"cpu": [
 				"arm64"
 			],
@@ -762,9 +762,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-			"integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.0.tgz",
+			"integrity": "sha512-Ogji1TQNqH3ACLnYr+1Ns1nyrJ0CO2P585u9Hsh02pXvtFiFpgtgT2b3P4PnCOU86VVCvqtAeCN4OftMT8KU4w==",
 			"cpu": [
 				"x64"
 			],
@@ -797,13 +797,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "24.12.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+			"version": "25.9.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+			"integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.16.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
 		"node_modules/esbuild": {
@@ -864,9 +864,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"version": "3.8.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+			"integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -880,13 +880,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-			"integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.0.tgz",
+			"integrity": "sha512-zpMvlJhs5PkXRTtKc0CaLBVI9AR/VDiJFpM+kx//hgToEca7FgMlGjaRIisXBcb19T76LswgmKECSQ96hjWr5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.133.0",
+				"@oxc-project/types": "=0.134.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -896,21 +896,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.3",
-				"@rolldown/binding-darwin-arm64": "1.0.3",
-				"@rolldown/binding-darwin-x64": "1.0.3",
-				"@rolldown/binding-freebsd-x64": "1.0.3",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.3",
-				"@rolldown/binding-linux-arm64-musl": "1.0.3",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.3",
-				"@rolldown/binding-linux-x64-gnu": "1.0.3",
-				"@rolldown/binding-linux-x64-musl": "1.0.3",
-				"@rolldown/binding-openharmony-arm64": "1.0.3",
-				"@rolldown/binding-wasm32-wasi": "1.0.3",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.3",
-				"@rolldown/binding-win32-x64-msvc": "1.0.3"
+				"@rolldown/binding-android-arm64": "1.1.0",
+				"@rolldown/binding-darwin-arm64": "1.1.0",
+				"@rolldown/binding-darwin-x64": "1.1.0",
+				"@rolldown/binding-freebsd-x64": "1.1.0",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.0",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.0",
+				"@rolldown/binding-linux-arm64-musl": "1.1.0",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.0",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.0",
+				"@rolldown/binding-linux-x64-gnu": "1.1.0",
+				"@rolldown/binding-linux-x64-musl": "1.1.0",
+				"@rolldown/binding-openharmony-arm64": "1.1.0",
+				"@rolldown/binding-wasm32-wasi": "1.1.0",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.0",
+				"@rolldown/binding-win32-x64-msvc": "1.1.0"
 			}
 		},
 		"node_modules/tslib": {
@@ -955,9 +955,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"dev": true,
 			"license": "MIT"
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@types/node": "^24.12.4",
 				"prettier": "^3.8.3",
 				"rolldown": "^1.0.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3"
 			}
 		},
@@ -47,6 +48,448 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -363,6 +806,63 @@
 				"undici-types": "~7.16.0"
 			}
 		},
+		"node_modules/esbuild": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.0",
+				"@esbuild/android-arm": "0.28.0",
+				"@esbuild/android-arm64": "0.28.0",
+				"@esbuild/android-x64": "0.28.0",
+				"@esbuild/darwin-arm64": "0.28.0",
+				"@esbuild/darwin-x64": "0.28.0",
+				"@esbuild/freebsd-arm64": "0.28.0",
+				"@esbuild/freebsd-x64": "0.28.0",
+				"@esbuild/linux-arm": "0.28.0",
+				"@esbuild/linux-arm64": "0.28.0",
+				"@esbuild/linux-ia32": "0.28.0",
+				"@esbuild/linux-loong64": "0.28.0",
+				"@esbuild/linux-mips64el": "0.28.0",
+				"@esbuild/linux-ppc64": "0.28.0",
+				"@esbuild/linux-riscv64": "0.28.0",
+				"@esbuild/linux-s390x": "0.28.0",
+				"@esbuild/linux-x64": "0.28.0",
+				"@esbuild/netbsd-arm64": "0.28.0",
+				"@esbuild/netbsd-x64": "0.28.0",
+				"@esbuild/openbsd-arm64": "0.28.0",
+				"@esbuild/openbsd-x64": "0.28.0",
+				"@esbuild/openharmony-arm64": "0.28.0",
+				"@esbuild/sunos-x64": "0.28.0",
+				"@esbuild/win32-arm64": "0.28.0",
+				"@esbuild/win32-ia32": "0.28.0",
+				"@esbuild/win32-x64": "0.28.0"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/prettier": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
@@ -420,6 +920,25 @@
 			"dev": true,
 			"license": "0BSD",
 			"optional": true
+		},
+		"node_modules/tsx": {
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.28.0"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
 	"sideEffects": false,
 	"scripts": {
 		"prepare": "npm run build",
-		"clean": "rm -rf dist .tmp",
+		"clean": "rm -rf dist",
 		"prebuild": "npm run clean",
 		"build": "npm run build:types && rolldown -c",
 		"build:types": "tsc -p tsconfig.build.json",
 		"typecheck": "npm run typecheck:src && npm run typecheck:test",
 		"typecheck:src": "tsc -p tsconfig.build.json --noEmit",
 		"typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-		"pretest": "rm -rf .tmp/test && tsc -p tsconfig.test.json",
-		"test": "node --test .tmp/test/*.test.js",
+		"pretest": "npm run typecheck:test",
+		"test": "node --import tsx --test src/*.test.ts",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"check": "npm run format:check && npm run typecheck && npm test && npm run build"
@@ -37,6 +37,7 @@
 		"@types/node": "^24.12.4",
 		"prettier": "^3.8.3",
 		"rolldown": "^1.0.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3"
 	},
 	"prettier": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
 		"check": "npm run format:check && npm run typecheck && npm test && npm run build"
 	},
 	"devDependencies": {
-		"@types/node": "^24.12.4",
-		"prettier": "^3.8.3",
-		"rolldown": "^1.0.3",
+		"@types/node": "^25.9.2",
+		"prettier": "^3.8.4",
+		"rolldown": "^1.1.0",
 		"tsx": "^4.22.4",
 		"typescript": "^6.0.3"
 	},

--- a/src/abstract-mutable-store.test.ts
+++ b/src/abstract-mutable-store.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, test } from "node:test";
 import { AbstractMutableStore } from "./abstract-mutable-store";
 
 function createMockStore<T>(initialValue: T, equalityFn?: (a: T, b: T) => boolean) {
@@ -8,13 +8,13 @@ function createMockStore<T>(initialValue: T, equalityFn?: (a: T, b: T) => boolea
 }
 
 describe("AbstractMutableStore", () => {
-	it("returns the initial value", () => {
+	test("returns the initial value", () => {
 		const store = createMockStore({ prop1: "value1", prop2: 42 });
 
 		assert.deepEqual(store.getSnapshot(), { prop1: "value1", prop2: 42 });
 	});
 
-	it("notifies listeners when the value changes", () => {
+	test("notifies listeners when the value changes", () => {
 		const calls: Array<{ prop1: string; prop2: number }> = [];
 		const store = createMockStore({
 			prop1: "value1",
@@ -27,7 +27,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(calls, [{ prop1: "newvalue", prop2: 99 }]);
 	});
 
-	it("does not notify listeners when the value is set to the same value", () => {
+	test("does not notify listeners when the value is set to the same value", () => {
 		const store = createMockStore({ prop1: "value1", prop2: 42 });
 		const calls: Array<{ prop1: string; prop2: number }> = [];
 
@@ -37,7 +37,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(calls, []);
 	});
 
-	it("uses the provided equality function", () => {
+	test("uses the provided equality function", () => {
 		const store = createMockStore(
 			{ version: 1, value: "old" },
 			(a, b) => a.version === b.version,
@@ -52,7 +52,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(store.getSnapshot(), { version: 2, value: "newer" });
 	});
 
-	it("uses the provided equality function from options", () => {
+	test("uses the provided equality function from options", () => {
 		class TestStore extends AbstractMutableStore<{ version: number; value: string }> {
 			constructor() {
 				super({ version: 1, value: "old" }, { equality: (a, b) => a.version === b.version });
@@ -70,7 +70,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(store.getSnapshot(), { version: 2, value: "newer" });
 	});
 
-	it("uses the provided clone function from options", () => {
+	test("uses the provided clone function from options", () => {
 		const callback = () => "value";
 
 		class TestStore extends AbstractMutableStore<{ name: string; callback: () => string }> {
@@ -89,7 +89,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(store.getSnapshot(), { name: "after", callback });
 	});
 
-	it("does not notify unsubscribed listeners", () => {
+	test("does not notify unsubscribed listeners", () => {
 		const store = createMockStore({ prop1: "value1", prop2: 42 });
 
 		const calls: Array<{ prop1: string; prop2: number }> = [];
@@ -105,7 +105,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(calls, [{ prop1: "newvalue", prop2: 99 }]);
 	});
 
-	it("allows unsubscribe to be called more than once", () => {
+	test("allows unsubscribe to be called more than once", () => {
 		const store = createMockStore({ count: 0 });
 		const calls: Array<{ count: number }> = [];
 
@@ -118,7 +118,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(calls, []);
 	});
 
-	it("safely mutates the draft value", () => {
+	test("safely mutates the draft value", () => {
 		class TestStore extends AbstractMutableStore<{ count: number }> {}
 
 		const store = new TestStore({ count: 0 });
@@ -134,7 +134,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(calls, [{ count: 1 }]);
 	});
 
-	it("uses replacement values returned by mutators", () => {
+	test("uses replacement values returned by mutators", () => {
 		const store = createMockStore({ count: 0 });
 
 		const result = store.mutate(() => ({ count: 10 }));
@@ -143,7 +143,7 @@ describe("AbstractMutableStore", () => {
 		assert.deepEqual(store.getSnapshot(), { count: 10 });
 	});
 
-	it("does not notify when a mutation leaves the value equal", () => {
+	test("does not notify when a mutation leaves the value equal", () => {
 		const store = createMockStore({ count: 0 });
 		const calls: Array<{ count: number }> = [];
 

--- a/src/base-equality.test.ts
+++ b/src/base-equality.test.ts
@@ -1,70 +1,70 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, test } from "node:test";
 import { isEqual as checkEquality } from "./base-equality";
 
 describe("checkEquality", () => {
-	it("returns true for identical objects", () => {
+	test("returns true for identical objects", () => {
 		const a = { x: 1, y: 2 };
 		const b = { x: 1, y: 2 };
 		assert.equal(checkEquality(a, b), true);
 	});
 
-	it("returns true for arrays with the same contents", () => {
+	test("returns true for arrays with the same contents", () => {
 		const a = [1, 2, 3];
 		const b = [1, 2, 3];
 		assert.equal(checkEquality(a, b), true);
 	});
 
-	it("returns false for objects with different values", () => {
+	test("returns false for objects with different values", () => {
 		const a = { x: 1, y: 2 };
 		const b = { x: 1, y: 3 };
 		assert.equal(checkEquality(a, b), false);
 	});
 
-	it("returns false for objects with different properties", () => {
+	test("returns false for objects with different properties", () => {
 		const a = { x: 1, y: 2 };
 		const b = { x: 1, z: 2 };
 		assert.equal(checkEquality(a, b), false);
 	});
 
-	it("returns false for arrays with different contents", () => {
+	test("returns false for arrays with different contents", () => {
 		const a = [1, 2, 3];
 		const b = [1, 2, 4];
 		assert.equal(checkEquality(a, b), false);
 	});
 
-	it("returns false for arrays with different lengths", () => {
+	test("returns false for arrays with different lengths", () => {
 		const a = [1, 2, 3];
 		const b = [1, 2];
 		assert.equal(checkEquality(a, b), false);
 	});
 
-	it("returns true for mixed objects and arrays", () => {
+	test("returns true for mixed objects and arrays", () => {
 		const a = { x: 1, y: [2, 3] };
 		const b = { x: 1, y: [2, 3] };
 		assert.equal(checkEquality(a, b), true);
 	});
 
-	it("returns true for Date values with the same timestamp", () => {
+	test("returns true for Date values with the same timestamp", () => {
 		const a = { createdAt: new Date("2026-06-06T12:00:00.000Z") };
 		const b = { createdAt: new Date("2026-06-06T12:00:00.000Z") };
 
 		assert.equal(checkEquality(a, b), true);
 	});
 
-	it("returns false for Date values with different timestamps", () => {
+	test("returns false for Date values with different timestamps", () => {
 		const a = { createdAt: new Date("2026-06-06T12:00:00.000Z") };
 		const b = { createdAt: new Date("2026-06-06T12:00:01.000Z") };
 
 		assert.equal(checkEquality(a, b), false);
 	});
 
-	it("preserves the difference between undefined fields and missing fields", () => {
+	test("preserves the difference between undefined fields and missing fields", () => {
 		assert.equal(checkEquality({ optional: undefined }, { optional: undefined }), true);
 		assert.equal(checkEquality({ optional: undefined }, {}), false);
 	});
 
-	it("returns true for Map and Set values with matching contents", () => {
+	test("returns true for Map and Set values with matching contents", () => {
 		const a = {
 			ids: new Set([1, 2]),
 			labels: new Map([
@@ -83,7 +83,7 @@ describe("checkEquality", () => {
 		assert.equal(checkEquality(a, b), true);
 	});
 
-	it("returns true for equivalent circular references", () => {
+	test("returns true for equivalent circular references", () => {
 		interface CircularState {
 			name: string;
 			self?: CircularState;
@@ -97,7 +97,7 @@ describe("checkEquality", () => {
 		assert.equal(checkEquality(a, b), true);
 	});
 
-	it("returns false for different circular references", () => {
+	test("returns false for different circular references", () => {
 		interface CircularState {
 			name: string;
 			self?: CircularState;
@@ -111,31 +111,31 @@ describe("checkEquality", () => {
 		assert.equal(checkEquality(a, b), false);
 	});
 
-	it("returns true for null values", () => {
+	test("returns true for null values", () => {
 		assert.equal(checkEquality(null, null), true);
 	});
 
-	it("returns false for null and undefined values", () => {
+	test("returns false for null and undefined values", () => {
 		assert.equal(checkEquality(null, undefined), false);
 	});
 
-	it("returns true for matching primitive values", () => {
+	test("returns true for matching primitive values", () => {
 		assert.equal(checkEquality("value", "value"), true);
 		assert.equal(checkEquality(1, 1), true);
 		assert.equal(checkEquality(true, true), true);
 	});
 
-	it("returns false for mismatched primitive values", () => {
+	test("returns false for mismatched primitive values", () => {
 		assert.equal(checkEquality("value", "other"), false);
 		assert.equal(checkEquality(1, 2), false);
 		assert.equal(checkEquality(true, false), false);
 	});
 
-	it("does not treat null as equal to NaN", () => {
+	test("does not treat null as equal to NaN", () => {
 		assert.equal(checkEquality(null, NaN), false);
 	});
 
-	it("only treats functions as equal when they are the same reference", () => {
+	test("only treats functions as equal when they are the same reference", () => {
 		const fn = () => undefined;
 
 		assert.equal(checkEquality(fn, fn), true);

--- a/src/mutate.test.ts
+++ b/src/mutate.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, test } from "node:test";
 import { mutate as safelyMutate } from "./mutate";
 
 describe("safelyMutate", () => {
-	it("safely mutates an object", () => {
+	test("safely mutates an object", () => {
 		const obj = { name: "John", age: 25 };
 		const newObj = safelyMutate(obj, (draft) => {
 			draft.name = "Jane";
@@ -13,7 +13,7 @@ describe("safelyMutate", () => {
 		assert.deepEqual(obj, { name: "John", age: 25 });
 	});
 
-	it("safely mutates an array", () => {
+	test("safely mutates an array", () => {
 		const arr = [1, 2, 3];
 		const newArr = safelyMutate(arr, (draft) => {
 			draft.push(4);
@@ -23,7 +23,7 @@ describe("safelyMutate", () => {
 		assert.deepEqual(arr, [1, 2, 3]);
 	});
 
-	it("clones Date values without converting them to strings", () => {
+	test("clones Date values without converting them to strings", () => {
 		const obj = { createdAt: new Date("2026-06-06T12:00:00.000Z"), name: "draft" };
 		const newObj = safelyMutate(obj, (draft) => {
 			draft.createdAt.setUTCFullYear(2027);
@@ -36,7 +36,7 @@ describe("safelyMutate", () => {
 		assert.deepEqual(obj, { createdAt: new Date("2026-06-06T12:00:00.000Z"), name: "draft" });
 	});
 
-	it("preserves undefined fields when cloning objects", () => {
+	test("preserves undefined fields when cloning objects", () => {
 		const obj: { name: string; optional: string | undefined } = {
 			name: "before",
 			optional: undefined,
@@ -52,7 +52,7 @@ describe("safelyMutate", () => {
 		assert.deepEqual(obj, { name: "before", optional: undefined });
 	});
 
-	it("clones Map and Set values", () => {
+	test("clones Map and Set values", () => {
 		const obj = {
 			ids: new Set([1, 2]),
 			labels: new Map([
@@ -79,7 +79,7 @@ describe("safelyMutate", () => {
 		]);
 	});
 
-	it("preserves circular references when cloning objects", () => {
+	test("preserves circular references when cloning objects", () => {
 		interface CircularState {
 			name: string;
 			self?: CircularState;
@@ -99,7 +99,7 @@ describe("safelyMutate", () => {
 		assert.equal(newObj.name, "after");
 	});
 
-	it("throws for function values with the default clone behavior", () => {
+	test("throws for function values with the default clone behavior", () => {
 		const obj = { name: "before", callback: () => "value" };
 
 		assert.throws(
@@ -111,7 +111,7 @@ describe("safelyMutate", () => {
 		);
 	});
 
-	it("uses a custom clone function for state that structuredClone cannot clone", () => {
+	test("uses a custom clone function for state that structuredClone cannot clone", () => {
 		const obj = { name: "before", callback: () => "value" };
 		const newObj = safelyMutate(
 			obj,
@@ -126,7 +126,7 @@ describe("safelyMutate", () => {
 		assert.deepEqual(obj, { name: "before", callback: obj.callback });
 	});
 
-	it("uses returned string values", () => {
+	test("uses returned string values", () => {
 		const str = "hello";
 		const newStr = safelyMutate(str, () => {
 			return "world";
@@ -135,7 +135,7 @@ describe("safelyMutate", () => {
 		assert.equal(str, "hello");
 	});
 
-	it("uses returned number values", () => {
+	test("uses returned number values", () => {
 		const value = 1;
 		const newValue = safelyMutate(value, () => 2);
 
@@ -143,7 +143,7 @@ describe("safelyMutate", () => {
 		assert.equal(value, 1);
 	});
 
-	it("uses replacement values returned for objects", () => {
+	test("uses replacement values returned for objects", () => {
 		const obj = { name: "John", age: 25 };
 		const newObj = safelyMutate(obj, () => ({ name: "Jane", age: 30 }));
 
@@ -151,7 +151,7 @@ describe("safelyMutate", () => {
 		assert.deepEqual(obj, { name: "John", age: 25 });
 	});
 
-	it("does not mutate the original value", () => {
+	test("does not mutate the original value", () => {
 		const obj = { name: "John", age: 25 };
 		safelyMutate(obj, (draft) => {
 			draft.name = "Jane";
@@ -171,7 +171,7 @@ describe("safelyMutate", () => {
 		assert.equal(str, "hello");
 	});
 
-	it("returns the original primitive value when no replacement is returned", () => {
+	test("returns the original primitive value when no replacement is returned", () => {
 		const value = 1;
 		const newValue = safelyMutate(value, () => {});
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,8 +4,6 @@
 		"declaration": false,
 		"module": "node16",
 		"moduleResolution": "node16",
-		"outDir": ".tmp/test",
-		"sourceMap": true,
 		"types": ["node"]
 	},
 	"include": ["src/**/*.ts"]


### PR DESCRIPTION
## Summary

- Adds `tsx` as a dev dependency so Node's test runner can execute TypeScript test files directly.
- Replaces the `.tmp/test` compile step with `node --import tsx --test src/*.test.ts`.
- Keeps `pretest` as a TypeScript type-check gate via `npm run typecheck:test`.
- Removes now-unused test `outDir` and source-map settings from `tsconfig.test.json`.

## Testing

- `npm run check`
- `npm pack --dry-run`
- `rg -n "\.tmp|tsx|node --test|pretest|typecheck:test" package.json package-lock.json tsconfig*.json .github src Readme.md`
- `find . -maxdepth 3 -name .tmp -print`
- `git diff --check`

## Notes/Risks

- This keeps `node:test` as the test framework and only swaps the TypeScript execution path.
- `npm test` still runs test type-checking first, so direct test runs do not become runtime-only.
